### PR TITLE
clean up fms_mp_mod and remove mp_bcst

### DIFF
--- a/model/boundary.F90
+++ b/model/boundary.F90
@@ -30,7 +30,6 @@ module boundary_mod
   use mpp_domains_mod,    only: AGRID, BGRID_NE, CGRID_NE, DGRID_NE
   use mpp_mod,            only: mpp_error, FATAL, mpp_sum, mpp_sync, mpp_npes, mpp_broadcast, WARNING, mpp_pe
 
-  use fv_mp_mod,          only: mp_bcst
   use fv_arrays_mod,      only: fv_atmos_type, fv_nest_BC_type_3D, fv_grid_bounds_type
   use mpp_mod,            only: mpp_send, mpp_recv
   use fv_timing_mod,      only: timing_on, timing_off

--- a/tools/fv_grid_tools.F90
+++ b/tools/fv_grid_tools.F90
@@ -32,7 +32,7 @@ module fv_grid_tools_mod
                            spherical_linear_interpolation, big_number
   use fv_timing_mod,  only: timing_on, timing_off
   use fv_mp_mod,      only: is_master, fill_corners, XDir, YDir
-  use fv_mp_mod,      only: mp_bcst, mp_reduce_max, mp_stop, grids_master_procs
+  use fv_mp_mod,      only: mp_reduce_max, mp_stop, grids_master_procs
   use sorted_index_mod,  only: sorted_inta, sorted_intb
   use mpp_mod,           only: mpp_error, FATAL, get_unit, mpp_chksum, mpp_pe, stdout, &
                                mpp_send, mpp_recv, mpp_sync_self, EVENT_RECV, mpp_npes, &

--- a/tools/fv_mp_mod.F90
+++ b/tools/fv_mp_mod.F90
@@ -33,6 +33,7 @@
       use mpp_mod,         only : mpp_declare_pelist, mpp_set_current_pelist, mpp_sync
       use mpp_mod,         only : mpp_clock_begin, mpp_clock_end, mpp_clock_id
       use mpp_mod,         only : mpp_chksum, stdout, stderr, mpp_broadcast
+      use mpp_mod,         only : mpp_min, mpp_max, mpp_sum
       use mpp_mod,         only : mpp_send, mpp_recv, mpp_sync_self, EVENT_RECV, mpp_gather
       use mpp_domains_mod, only : GLOBAL_DATA_DOMAIN, BITWISE_EXACT_SUM, BGRID_NE, FOLD_NORTH_EDGE, CGRID_NE
       use mpp_domains_mod, only : MPP_DOMAIN_TIME, CYCLIC_GLOBAL_DOMAIN, NUPDATE,EUPDATE, XUPDATE, YUPDATE, SCALAR_PAIR
@@ -94,7 +95,7 @@
       type(nest_domain_type) :: global_nest_domain !ONE structure for ALL levels of nesting
 
       public mp_start, mp_assign_gid, mp_barrier, mp_stop!, npes
-      public domain_decomp, mp_bcst, mp_reduce_max, mp_reduce_sum, mp_gather
+      public domain_decomp, mp_reduce_max, mp_reduce_sum, mp_gather
       public mp_reduce_min
       public fill_corners, XDir, YDir
       public switch_current_domain, switch_current_Atm, broadcast_domains
@@ -133,24 +134,6 @@
       INTERFACE fill_corners_dgrid
         MODULE PROCEDURE fill_corners_dgrid_r4
         MODULE PROCEDURE fill_corners_dgrid_r8
-      END INTERFACE
-
-      INTERFACE mp_bcst
-        MODULE PROCEDURE mp_bcst_i4
-        MODULE PROCEDURE mp_bcst_r4
-        MODULE PROCEDURE mp_bcst_r8
-        MODULE PROCEDURE mp_bcst_1d_r4
-        MODULE PROCEDURE mp_bcst_1d_r8
-        MODULE PROCEDURE mp_bcst_2d_r4
-        MODULE PROCEDURE mp_bcst_2d_r8
-        MODULE PROCEDURE mp_bcst_3d_r4
-        MODULE PROCEDURE mp_bcst_3d_r8
-        MODULE PROCEDURE mp_bcst_4d_r4
-        MODULE PROCEDURE mp_bcst_4d_r8
-        MODULE PROCEDURE mp_bcst_1d_i
-        MODULE PROCEDURE mp_bcst_2d_i
-        MODULE PROCEDURE mp_bcst_3d_i8
-        MODULE PROCEDURE mp_bcst_4d_i8
       END INTERFACE
 
       INTERFACE mp_reduce_min
@@ -1474,7 +1457,6 @@ end subroutine switch_current_Atm
             Ldispl(l) = 5*(l-1)
          enddo
          call mpp_gather(Ldims, Gdims)
-!         call MPI_GATHERV(Ldims, 5, MPI_INTEGER, Gdims, cnts, Ldispl, MPI_INTEGER, masterproc, commglobal, ierror)
 
          Lsize = ( (i2 - i1 + 1) * (j2 - j1 + 1) ) * kdim
          do l=1,npes_this_grid
@@ -1484,7 +1466,6 @@ end subroutine switch_current_Atm
          LsizeS(:)=1
          Lsize_buf(1) = Lsize
          call mpp_gather(Lsize_buf, LsizeS)
-!         call MPI_GATHERV(Lsize, 1, MPI_INTEGER, LsizeS, cnts, Ldispl, MPI_INTEGER, masterproc, commglobal, ierror)
 
          allocate ( larr(Lsize) )
          icnt = 1
@@ -1497,18 +1478,15 @@ end subroutine switch_current_Atm
             enddo
          enddo
          Ldispl(1) = 0.0
-!         call mp_bcst(LsizeS(1))
          call mpp_broadcast(LsizeS, npes_this_grid, masterproc)
          Gsize = LsizeS(1)
          do l=2,npes_this_grid
-!            call mp_bcst(LsizeS(l))
             Ldispl(l) = Ldispl(l-1) + LsizeS(l-1)
             Gsize = Gsize + LsizeS(l)
          enddo
          allocate ( garr(Gsize) )
 
          call mpp_gather(larr, Lsize, garr, LsizeS)
-!         call MPI_GATHERV(larr, Lsize, MPI_REAL, garr, LsizeS, Ldispl, MPI_REAL, masterproc, commglobal, ierror)
 
          if (gid==masterproc) then
             do n=2,npes_this_grid
@@ -1559,7 +1537,6 @@ end subroutine switch_current_Atm
             cnts(l) = 5
             Ldispl(l) = 5*(l-1)
          enddo
-!         call MPI_GATHERV(Ldims, 5, MPI_INTEGER, Gdims, cnts, Ldispl, MPI_INTEGER, masterproc, commglobal, ierror)
          call mpp_gather(Ldims, Gdims)
 
          Lsize = ( (i2 - i1 + 1) * (j2 - j1 + 1) )
@@ -1570,7 +1547,6 @@ end subroutine switch_current_Atm
          LsizeS(:)=1
          Lsize_buf(1) = Lsize
          call mpp_gather(Lsize_buf, LsizeS)
-!         call MPI_GATHERV(Lsize, 1, MPI_INTEGER, LsizeS, cnts, Ldispl, MPI_INTEGER, masterproc, commglobal, ierror)
 
          allocate ( larr(Lsize) )
          icnt = 1
@@ -1581,17 +1557,14 @@ end subroutine switch_current_Atm
             enddo
          enddo
          Ldispl(1) = 0.0
-!         call mp_bcst(LsizeS(1))
          call mpp_broadcast(LsizeS, npes_this_grid, masterproc)
          Gsize = LsizeS(1)
          do l=2,npes_this_grid
-!            call mp_bcst(LsizeS(l))
             Ldispl(l) = Ldispl(l-1) + LsizeS(l-1)
             Gsize = Gsize + LsizeS(l)
          enddo
          allocate ( garr(Gsize) )
          call mpp_gather(larr, Lsize, garr, LsizeS)
-!         call MPI_GATHERV(larr, Lsize, MPI_REAL, garr, LsizeS, Ldispl, MPI_REAL, masterproc, commglobal, ierror)
          if (gid==masterproc) then
             do n=2,npes_this_grid
                icnt=1
@@ -1647,7 +1620,6 @@ end subroutine switch_current_Atm
          enddo
          LsizeS(:)=0.
 
-!         call MPI_GATHERV(Lsize, 1, MPI_INTEGER, LsizeS, cnts, Ldispl, MPI_INTEGER, masterproc, commglobal, ierror)
          Lsize_buf(1) = Lsize
          call mpp_gather(Lsize_buf, LsizeS)
 
@@ -1661,17 +1633,14 @@ end subroutine switch_current_Atm
          enddo
          Ldispl(1) = 0.0
          call mpp_broadcast(LsizeS, npes_this_grid, masterproc)
-!         call mp_bcst(LsizeS(1))
          Gsize = LsizeS(1)
          do l=2,npes_this_grid
-!            call mp_bcst(LsizeS(l))
             Ldispl(l) = Ldispl(l-1) + LsizeS(l-1)
             Gsize = Gsize + LsizeS(l)
          enddo
 
          allocate ( garr(Gsize) )
          call mpp_gather(larr, Lsize, garr, LsizeS)
-!         call MPI_GATHERV(larr, Lsize, MPI_DOUBLE_PRECISION, garr, LsizeS, Ldispl, MPI_DOUBLE_PRECISION, masterproc, commglobal, ierror)
          if (gid==masterproc) then
             do n=2,npes_this_grid
                icnt=1
@@ -1693,243 +1662,6 @@ end subroutine switch_current_Atm
 ! ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ !
 !-------------------------------------------------------------------------------
 
-!-------------------------------------------------------------------------------
-! vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv !
-!
-!     mp_bcst_i4 :: Call SPMD broadcast
-!
-      subroutine mp_bcst_i4(q)
-         integer, intent(INOUT)  :: q
-
-         call MPI_BCAST(q, 1, MPI_INTEGER, masterproc, commglobal, ierror)
-
-      end subroutine mp_bcst_i4
-!
-! ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ !
-!-------------------------------------------------------------------------------
-
-!-------------------------------------------------------------------------------
-! vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv !
-!
-!     mp_bcst_r4 :: Call SPMD broadcast
-!
-      subroutine mp_bcst_r4(q)
-         real(kind=4), intent(INOUT)  :: q
-
-         call MPI_BCAST(q, 1, MPI_REAL, masterproc, commglobal, ierror)
-
-      end subroutine mp_bcst_r4
-!
-! ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ !
-!-------------------------------------------------------------------------------
-
-!-------------------------------------------------------------------------------
-! vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv !
-!
-!     mp_bcst_r8 :: Call SPMD broadcast
-!
-      subroutine mp_bcst_r8(q)
-         real(kind=8), intent(INOUT)  :: q
-
-         call MPI_BCAST(q, 1, MPI_DOUBLE_PRECISION, masterproc, commglobal, ierror)
-
-      end subroutine mp_bcst_r8
-!
-! ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ !
-!-------------------------------------------------------------------------------
-
-!-------------------------------------------------------------------------------
-! vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv !
-!
-!     mp_bcst_1d_r4 :: Call SPMD broadcast
-!
-      subroutine mp_bcst_1d_r4(q, idim)
-         integer, intent(IN)  :: idim
-         real(kind=4), intent(INOUT)  :: q(idim)
-
-         call MPI_BCAST(q, idim, MPI_REAL, masterproc, commglobal, ierror)
-
-      end subroutine mp_bcst_1d_r4
-!
-! ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ !
-!-------------------------------------------------------------------------------
-
-!-------------------------------------------------------------------------------
-! vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv !
-!
-!     mp_bcst_1d_r8 :: Call SPMD broadcast
-!
-      subroutine mp_bcst_1d_r8(q, idim)
-         integer, intent(IN)  :: idim
-         real(kind=8), intent(INOUT)  :: q(idim)
-
-         call MPI_BCAST(q, idim, MPI_DOUBLE_PRECISION, masterproc, commglobal, ierror)
-
-      end subroutine mp_bcst_1d_r8
-!
-! ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ !
-!-------------------------------------------------------------------------------
-
-!-------------------------------------------------------------------------------
-! vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv !
-!
-!     mp_bcst_2d_r4 :: Call SPMD broadcast
-!
-      subroutine mp_bcst_2d_r4(q, idim, jdim)
-         integer, intent(IN)  :: idim, jdim
-         real(kind=4), intent(INOUT)  :: q(idim,jdim)
-
-         call MPI_BCAST(q, idim*jdim, MPI_REAL, masterproc, commglobal, ierror)
-
-      end subroutine mp_bcst_2d_r4
-!
-! ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ !
-!-------------------------------------------------------------------------------
-
-!-------------------------------------------------------------------------------
-! vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv !
-!
-!     mp_bcst_2d_r8 :: Call SPMD broadcast
-!
-      subroutine mp_bcst_2d_r8(q, idim, jdim)
-         integer, intent(IN)  :: idim, jdim
-         real(kind=8), intent(INOUT)  :: q(idim,jdim)
-
-         call MPI_BCAST(q, idim*jdim, MPI_DOUBLE_PRECISION, masterproc, commglobal, ierror)
-
-      end subroutine mp_bcst_2d_r8
-!
-! ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ !
-!-------------------------------------------------------------------------------
-
-!-------------------------------------------------------------------------------
-! vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv !
-!
-!     mp_bcst_3d_r4 :: Call SPMD broadcast
-!
-      subroutine mp_bcst_3d_r4(q, idim, jdim, kdim)
-         integer, intent(IN)  :: idim, jdim, kdim
-         real(kind=4), intent(INOUT)  :: q(idim,jdim,kdim)
-
-         call MPI_BCAST(q, idim*jdim*kdim, MPI_REAL, masterproc, commglobal, ierror)
-
-      end subroutine mp_bcst_3d_r4
-!
-! ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ !
-!-------------------------------------------------------------------------------
-
-!-------------------------------------------------------------------------------
-! vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv !
-!
-!     mp_bcst_3d_r8 :: Call SPMD broadcast
-!
-      subroutine mp_bcst_3d_r8(q, idim, jdim, kdim)
-         integer, intent(IN)  :: idim, jdim, kdim
-         real(kind=8), intent(INOUT)  :: q(idim,jdim,kdim)
-
-         call MPI_BCAST(q, idim*jdim*kdim, MPI_DOUBLE_PRECISION, masterproc, commglobal, ierror)
-
-      end subroutine mp_bcst_3d_r8
-!
-! ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ !
-!-------------------------------------------------------------------------------
-
-!-------------------------------------------------------------------------------
-! vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv !
-!
-!     mp_bcst_4d_r4 :: Call SPMD broadcast
-!
-      subroutine mp_bcst_4d_r4(q, idim, jdim, kdim, ldim)
-         integer, intent(IN)  :: idim, jdim, kdim, ldim
-         real(kind=4), intent(INOUT)  :: q(idim,jdim,kdim,ldim)
-
-         call MPI_BCAST(q, idim*jdim*kdim*ldim, MPI_REAL, masterproc, commglobal, ierror)
-
-      end subroutine mp_bcst_4d_r4
-!
-! ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ !
-!-------------------------------------------------------------------------------
-
-!-------------------------------------------------------------------------------
-! vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv !
-!
-!     mp_bcst_4d_r8 :: Call SPMD broadcast
-!
-      subroutine mp_bcst_4d_r8(q, idim, jdim, kdim, ldim)
-         integer, intent(IN)  :: idim, jdim, kdim, ldim
-         real(kind=8), intent(INOUT)  :: q(idim,jdim,kdim,ldim)
-
-         call MPI_BCAST(q, idim*jdim*kdim*ldim, MPI_DOUBLE_PRECISION, masterproc, commglobal, ierror)
-
-      end subroutine mp_bcst_4d_r8
-!
-! ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ !
-!-------------------------------------------------------------------------------
-
-!-------------------------------------------------------------------------------
-! vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv !
-!
-!     mp_bcst_1d_i :: Call SPMD broadcast
-!
-      subroutine mp_bcst_1d_i(q, idim)
-         integer, intent(IN)  :: idim
-         integer, intent(INOUT)  :: q(idim)
-
-         call MPI_BCAST(q, idim, MPI_INTEGER, masterproc, commglobal, ierror)
-
-      end subroutine mp_bcst_1d_i
-!
-! ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ !
-!-------------------------------------------------------------------------------
-
-!-------------------------------------------------------------------------------
-! vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv !
-!
-!     mp_bcst_2d_i :: Call SPMD broadcast
-!
-      subroutine mp_bcst_2d_i(q, idim, jdim)
-         integer, intent(IN)  :: idim, jdim
-         integer, intent(INOUT)  :: q(idim,jdim)
-
-         call MPI_BCAST(q, idim*jdim, MPI_INTEGER, masterproc, commglobal, ierror)
-
-      end subroutine mp_bcst_2d_i
-!
-! ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ !
-!-------------------------------------------------------------------------------
-
-!-------------------------------------------------------------------------------
-! vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv !
-!
-!     mp_bcst_3d_i8 :: Call SPMD broadcast
-!
-      subroutine mp_bcst_3d_i8(q, idim, jdim, kdim)
-         integer, intent(IN)  :: idim, jdim, kdim
-         integer, intent(INOUT)  :: q(idim,jdim,kdim)
-
-         call MPI_BCAST(q, idim*jdim*kdim, MPI_INTEGER, masterproc, commglobal, ierror)
-
-      end subroutine mp_bcst_3d_i8
-!
-! ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ !
-!-------------------------------------------------------------------------------
-
-!-------------------------------------------------------------------------------
-! vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv !
-!
-!     mp_bcst_4d_i8 :: Call SPMD broadcast
-!
-      subroutine mp_bcst_4d_i8(q, idim, jdim, kdim, ldim)
-         integer, intent(IN)  :: idim, jdim, kdim, ldim
-         integer, intent(INOUT)  :: q(idim,jdim,kdim,ldim)
-
-         call MPI_BCAST(q, idim*jdim*kdim*ldim, MPI_INTEGER, masterproc, commglobal, ierror)
-
-      end subroutine mp_bcst_4d_i8
-!
-! ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ !
-!-------------------------------------------------------------------------------
-
 
 !-------------------------------------------------------------------------------
 ! vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv !
@@ -1942,10 +1674,11 @@ end subroutine switch_current_Atm
 
          real(kind=4) :: gmax(npts)
 
-         call MPI_ALLREDUCE( mymax, gmax, npts, MPI_REAL, MPI_MAX, &
-                             commglobal, ierror )
-
-         mymax = gmax
+         call mpp_max (mymax, npts)
+!         call MPI_ALLREDUCE( mymax, gmax, npts, MPI_REAL, MPI_MAX, &
+!                             commglobal, ierror )
+!
+!         mymax = gmax
 
       end subroutine mp_reduce_max_r4_1d
 !
@@ -1964,10 +1697,11 @@ end subroutine switch_current_Atm
 
          real(kind=8) :: gmax(npts)
 
-         call MPI_ALLREDUCE( mymax, gmax, npts, MPI_DOUBLE_PRECISION, MPI_MAX, &
-                             commglobal, ierror )
-
-         mymax = gmax
+         call mpp_max (mymax, npts)
+!         call MPI_ALLREDUCE( mymax, gmax, npts, MPI_DOUBLE_PRECISION, MPI_MAX, &
+!                             commglobal, ierror )
+!
+!         mymax = gmax
 
       end subroutine mp_reduce_max_r8_1d
 !
@@ -1985,10 +1719,11 @@ end subroutine switch_current_Atm
 
          real(kind=4) :: gmax
 
-         call MPI_ALLREDUCE( mymax, gmax, 1, MPI_REAL, MPI_MAX, &
-                             commglobal, ierror )
-
-         mymax = gmax
+         call mpp_max (mymax)
+!         call MPI_ALLREDUCE( mymax, gmax, 1, MPI_REAL, MPI_MAX, &
+!                             commglobal, ierror )
+!
+!         mymax = gmax
 
       end subroutine mp_reduce_max_r4
 
@@ -2002,10 +1737,11 @@ end subroutine switch_current_Atm
 
          real(kind=8) :: gmax
 
-         call MPI_ALLREDUCE( mymax, gmax, 1, MPI_DOUBLE_PRECISION, MPI_MAX, &
-                             commglobal, ierror )
-
-         mymax = gmax
+         call mpp_max (mymax)
+!         call MPI_ALLREDUCE( mymax, gmax, 1, MPI_DOUBLE_PRECISION, MPI_MAX, &
+!                             commglobal, ierror )
+!
+!         mymax = gmax
 
       end subroutine mp_reduce_max_r8
 
@@ -2014,10 +1750,11 @@ end subroutine switch_current_Atm
 
          real(kind=4) :: gmin
 
-         call MPI_ALLREDUCE( mymin, gmin, 1, MPI_REAL, MPI_MIN, &
-                             commglobal, ierror )
-
-         mymin = gmin
+         call mpp_min (mymin)
+!         call MPI_ALLREDUCE( mymin, gmin, 1, MPI_REAL, MPI_MIN, &
+!                             commglobal, ierror )
+!
+!         mymin = gmin
 
       end subroutine mp_reduce_min_r4
 
@@ -2026,10 +1763,11 @@ end subroutine switch_current_Atm
 
          real(kind=8) :: gmin
 
-         call MPI_ALLREDUCE( mymin, gmin, 1, MPI_DOUBLE_PRECISION, MPI_MIN, &
-                             commglobal, ierror )
-
-         mymin = gmin
+         call mpp_min (mymin)
+!         call MPI_ALLREDUCE( mymin, gmin, 1, MPI_DOUBLE_PRECISION, MPI_MIN, &
+!                             commglobal, ierror )
+!
+!         mymin = gmin
 
       end subroutine mp_reduce_min_r8
 !
@@ -2039,17 +1777,18 @@ end subroutine switch_current_Atm
 !-------------------------------------------------------------------------------
 ! vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv !
 !
-!     mp_bcst_4d_i4 :: Call SPMD REDUCE_MAX
+!     mp_reduce_max_i4 :: Call SPMD REDUCE_MAX
 !
       subroutine mp_reduce_max_i4(mymax)
          integer, intent(INOUT)  :: mymax
 
          integer :: gmax
 
-         call MPI_ALLREDUCE( mymax, gmax, 1, MPI_INTEGER, MPI_MAX, &
-                             commglobal, ierror )
-
-         mymax = gmax
+         call mpp_max(mymax)
+!         call MPI_ALLREDUCE( mymax, gmax, 1, MPI_INTEGER, MPI_MAX, &
+!                             commglobal, ierror )
+!
+!         mymax = gmax
 
       end subroutine mp_reduce_max_i4
 !
@@ -2066,10 +1805,11 @@ end subroutine switch_current_Atm
 
          real(kind=4) :: gsum
 
-         call MPI_ALLREDUCE( mysum, gsum, 1, MPI_REAL, MPI_SUM, &
-                             commglobal, ierror )
-
-         mysum = gsum
+         call mpp_sum(mysum)
+!         call MPI_ALLREDUCE( mysum, gsum, 1, MPI_REAL, MPI_SUM, &
+!                             commglobal, ierror )
+!
+!         mysum = gsum
 
       end subroutine mp_reduce_sum_r4
 !
@@ -2086,10 +1826,11 @@ end subroutine switch_current_Atm
 
          real(kind=8) :: gsum
 
-         call MPI_ALLREDUCE( mysum, gsum, 1, MPI_DOUBLE_PRECISION, MPI_SUM, &
-                             commglobal, ierror )
-
-         mysum = gsum
+         call mpp_sum (mysum)
+!         call MPI_ALLREDUCE( mysum, gsum, 1, MPI_DOUBLE_PRECISION, MPI_SUM, &
+!                             commglobal, ierror )
+!
+!         mysum = gsum
 
       end subroutine mp_reduce_sum_r8
 !
@@ -2114,10 +1855,11 @@ end subroutine switch_current_Atm
             mysum = mysum + sum1d(i)
          enddo
 
-         call MPI_ALLREDUCE( mysum, gsum, 1, MPI_DOUBLE_PRECISION, MPI_SUM, &
-                             commglobal, ierror )
-
-         mysum = gsum
+         call mpp_sum (mysum)
+!         call MPI_ALLREDUCE( mysum, gsum, 1, MPI_DOUBLE_PRECISION, MPI_SUM, &
+!                             commglobal, ierror )
+!
+!         mysum = gsum
 
       end subroutine mp_reduce_sum_r4_1d
 !
@@ -2142,10 +1884,11 @@ end subroutine switch_current_Atm
             mysum = mysum + sum1d(i)
          enddo
 
-         call MPI_ALLREDUCE( mysum, gsum, 1, MPI_DOUBLE_PRECISION, MPI_SUM, &
-                             commglobal, ierror )
-
-         mysum = gsum
+         call mpp_sum (mysum)
+!         call MPI_ALLREDUCE( mysum, gsum, 1, MPI_DOUBLE_PRECISION, MPI_SUM, &
+!                             commglobal, ierror )
+!
+!         mysum = gsum
 
       end subroutine mp_reduce_sum_r8_1d
 !
@@ -2162,11 +1905,12 @@ end subroutine switch_current_Atm
          real(kind=4), intent(inout)  :: mysum(npts)
          real(kind=4)                 :: gsum(npts)
 
-         gsum = 0.0
-         call MPI_ALLREDUCE( mysum, gsum, npts, MPI_REAL, MPI_SUM, &
-                             commglobal, ierror )
-
-         mysum = gsum
+         call mpp_sum (mysum, npts)
+!         gsum = 0.0
+!         call MPI_ALLREDUCE( mysum, gsum, npts, MPI_REAL, MPI_SUM, &
+!                             commglobal, ierror )
+!
+!         mysum = gsum
 
       end subroutine mp_reduce_sum_r4_1darr
 !
@@ -2183,11 +1927,12 @@ end subroutine switch_current_Atm
          real(kind=4), intent(inout)  :: mysum(npts1,npts2)
          real(kind=4)                 :: gsum(npts1,npts2)
 
-         gsum = 0.0
-         call MPI_ALLREDUCE( mysum, gsum, npts1*npts2, MPI_REAL, MPI_SUM, &
-                             commglobal, ierror )
-
-         mysum = gsum
+         call mpp_sum (mysum, npts1*npts2)
+!         gsum = 0.0
+!         call MPI_ALLREDUCE( mysum, gsum, npts1*npts2, MPI_REAL, MPI_SUM, &
+!                             commglobal, ierror )
+!
+!         mysum = gsum
 
       end subroutine mp_reduce_sum_r4_2darr
 !
@@ -2204,13 +1949,13 @@ end subroutine switch_current_Atm
          real(kind=8), intent(inout)  :: mysum(npts)
          real(kind=8)                 :: gsum(npts)
 
-         gsum = 0.0
-
-         call MPI_ALLREDUCE( mysum, gsum, npts, MPI_DOUBLE_PRECISION, &
-                             MPI_SUM,                                 &
-                             commglobal, ierror )
-
-         mysum = gsum
+         call mpp_sum (mysum, npts)
+!         gsum = 0.0
+!         call MPI_ALLREDUCE( mysum, gsum, npts, MPI_DOUBLE_PRECISION, &
+!                             MPI_SUM,                                 &
+!                             commglobal, ierror )
+!
+!         mysum = gsum
 
       end subroutine mp_reduce_sum_r8_1darr
 !
@@ -2227,13 +1972,13 @@ end subroutine switch_current_Atm
          real(kind=8), intent(inout)  :: mysum(npts1,npts2)
          real(kind=8)                 :: gsum(npts1,npts2)
 
-         gsum = 0.0
-
-         call MPI_ALLREDUCE( mysum, gsum, npts1*npts2,      &
-                             MPI_DOUBLE_PRECISION, MPI_SUM, &
-                             commglobal, ierror )
-
-         mysum = gsum
+         call mpp_sum (mysum, npts1*npts2)
+!         gsum = 0.0
+!         call MPI_ALLREDUCE( mysum, gsum, npts1*npts2,      &
+!                             MPI_DOUBLE_PRECISION, MPI_SUM, &
+!                             commglobal, ierror )
+!
+!         mysum = gsum
 
       end subroutine mp_reduce_sum_r8_2darr
 !

--- a/tools/test_cases.F90
+++ b/tools/test_cases.F90
@@ -26,7 +26,7 @@
       use init_hydro_mod,    only: p_var, hydro_eq, hydro_eq_ext
       use fv_mp_mod,         only: is_master,        &
                                    domain_decomp, fill_corners, XDir, YDir, &
-                                   mp_stop, mp_reduce_sum, mp_reduce_max, mp_gather, mp_bcst
+                                   mp_stop, mp_reduce_sum, mp_reduce_max, mp_gather
       use fv_grid_utils_mod, only: cubed_to_latlon, great_circle_dist, mid_pt_sphere,    &
                                    ptop_min, inner_prod, get_latlon_vector, get_unit_vect2, &
                                    g_sum, latlon2xyz, cart_to_latlon, make_eta_level, f_p, project_sphere_v


### PR DESCRIPTION
**Description**
Clean up fms_mp_mod by removing mp_bcst and using mpp_min/max/sum in mp_reduce_min/max/sum wrappers.

Fixes # (issue)
CI solo tests have been run for GNU and Intel and a couple of SHiELD cases have also been run.

**Checklist:**

Please check all whether they apply or not
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
